### PR TITLE
Install mcrypt with pecl on PHP 7.2

### DIFF
--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -5,8 +5,10 @@ class mcrypt (
 ) {
 	if ( ! empty( $::config[disabled_extensions] ) and 'chassis/mcrypt' in $config[disabled_extensions] ) {
 		$package = absent
+		$file = absent
 	} else {
 		$package = latest
+		$file = present
 	}
 
 	$php = $config[php]
@@ -28,7 +30,7 @@ class mcrypt (
 		}
 
 		if ! defined( Package['libmcrypt-dev'] ) {
-			package { "libmcrypt-dev":
+			package { 'libmcrypt-dev':
 				ensure  => $package,
 				require => Package["php${config[php]}-dev"]
 			}

--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -21,7 +21,7 @@ class mcrypt (
 	}
 
 	# Mcyrpt isn't shipped in PHP 7.2 anymore but occasionally developers might need to still use it locally.
-	if versioncmp( $php, '5.4' ) >= 0 and versioncmp( $php, '7.1' ) >= 0 {
+	if versioncmp( $php, '5.4' ) >= 0 and versioncmp( $php, '7.2' ) >= 0 {
 		if ! defined( Package["php${config[php]}-dev"] ) {
 			package { "php${config[php]}-dev":
 				ensure  => $package,

--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -21,7 +21,7 @@ class mcrypt (
 	}
 
 	# Mcyrpt isn't shipped in PHP 7.2 anymore but occasionally developers might need to still use it locally.
-	if versioncmp( $php, '5.4' ) >= 0 and versioncmp( $php, '7.2' ) == 0 {
+	if versioncmp( $php, '5.4' ) >= 0 and versioncmp( $php, '7.1' ) >= 0 {
 		if ! defined( Package["php${config[php]}-dev"] ) {
 			package { "php${config[php]}-dev":
 				ensure  => $package,
@@ -42,23 +42,25 @@ class mcrypt (
 			}
 		}
 
-		exec { 'pecl install mcrypt for PHP 7.2':
+		exec { 'pecl install mcrypt for PHP 7.2+':
 			path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
 			command => 'pecl install mcrypt-1.0.1',
-			require => Package['php-pear'],
+			require => [ Package['php-pear'], Package["php${config[php]}-dev"] ],
 			unless  => 'pecl info mcrypt-1.0.1',
 		}
 
 		file { "/etc/php/${php}/cli/conf.d/mcrypt.ini":
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
-			notify  => Service["${$php_package}-fpm"]
+			notify  => Service["${$php_package}-fpm"],
+			require =>'pecl install mcrypt for PHP 7.2+',
 		}
 
 		file { "/etc/php/${php}/fpm/conf.d/mcrypt.ini":
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
-			notify  => Service["${$php_package}-fpm"]
+			notify  => Service["${$php_package}-fpm"],
+			require =>'pecl install mcrypt for PHP 7.2+',
 		}
 
 	} else {

--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -53,14 +53,14 @@ class mcrypt (
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
 			notify  => Service["${$php_package}-fpm"],
-			require => 'pecl install mcrypt for PHP 7.2+',
+			require => Exec[ 'pecl install mcrypt for PHP 7.2+' ],
 		}
 
 		file { "/etc/php/${php}/fpm/conf.d/mcrypt.ini":
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
 			notify  => Service["${$php_package}-fpm"],
-			require => 'pecl install mcrypt for PHP 7.2+',
+			require => Exec[ 'pecl install mcrypt for PHP 7.2+' ],
 		}
 
 	} else {

--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -18,9 +18,52 @@ class mcrypt (
 		$php_package = "php${$php}"
 	}
 
-	package { "${$php_package}-mcrypt":
-		ensure  => $package,
-		require => Package["${$php_package}-fpm"],
-		notify  => Service["${$php_package}-fpm"]
+	# Mcyrpt isn't shipped in PHP 7.2 anymore but occasionally developers might need to still use it locally.
+	if versioncmp( $php, '5.4' ) >= 0 and versioncmp( $php, '7.2' ) == 0 {
+		if ! defined( Package["php${config[php]}-dev"] ) {
+			package { "php${config[php]}-dev":
+				ensure  => $package,
+				require => Package["php${config[php]}-fpm"]
+			}
+		}
+
+		if ! defined( Package['libmcrypt-dev'] ) {
+			package { "libmcrypt-dev":
+				ensure  => $package,
+				require => Package["php${config[php]}-dev"]
+			}
+		}
+
+		if ! defined( Package['php-pear'] ) {
+			package { 'php-pear':
+			  ensure => installed,
+			}
+		}
+
+		exec { 'pecl install mcrypt for PHP 7.2':
+			path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+			command => 'pecl install mcrypt-1.0.1',
+			require => Package['php-pear'],
+			unless  => 'pecl info mcrypt-1.0.1',
+		}
+
+		file { "/etc/php/${php}/cli/conf.d/mcrypt.ini":
+			ensure  => $file,
+			content => template('mcrypt/mcrypt.ini.erb'),
+			notify  => Service["${$php_package}-fpm"]
+		}
+
+		file { "/etc/php/${php}/fpm/conf.d/mcrypt.ini":
+			ensure  => $file,
+			content => template('mcrypt/mcrypt.ini.erb'),
+			notify  => Service["${$php_package}-fpm"]
+		}
+
+	} else {
+		package { "${$php_package}-mcrypt":
+		  ensure  => $package,
+		  require => Package["${$php_package}-fpm"],
+		  notify  => Service["${$php_package}-fpm"]
+		}
 	}
 }

--- a/modules/mcrypt/manifests/init.pp
+++ b/modules/mcrypt/manifests/init.pp
@@ -53,14 +53,14 @@ class mcrypt (
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
 			notify  => Service["${$php_package}-fpm"],
-			require =>'pecl install mcrypt for PHP 7.2+',
+			require => 'pecl install mcrypt for PHP 7.2+',
 		}
 
 		file { "/etc/php/${php}/fpm/conf.d/mcrypt.ini":
 			ensure  => $file,
 			content => template('mcrypt/mcrypt.ini.erb'),
 			notify  => Service["${$php_package}-fpm"],
-			require =>'pecl install mcrypt for PHP 7.2+',
+			require => 'pecl install mcrypt for PHP 7.2+',
 		}
 
 	} else {

--- a/modules/mcrypt/templates/mcrypt.ini.erb
+++ b/modules/mcrypt/templates/mcrypt.ini.erb
@@ -1,0 +1,1 @@
+extension=mcrypt.so


### PR DESCRIPTION
Fixes #7

Tested on:
- [x] PHP 5.6
- [x] PHP 7.0
- [x] PHP 7.1
- [x] PHP 7.2
- [x] PHP 7.3